### PR TITLE
feat: build and push docker image in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  # TODO: build nightly image
   # schedule:
   #   - cron: '22 3 * * *'
   push:
@@ -12,14 +13,13 @@ on:
 
 env:
   # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
+  REGISTRY: ${{ github.repository_owner != 'nervosnetwork' && 'ghcr.io/' || '' }}
   # github.repository as <account>/<repo>
   IMAGE_NAME: godwoken-prebuilds
 
 
 jobs:
-  build:
-
+  docker-build-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,8 +62,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHP_CRT }}
+          username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.GHP_CRT }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -71,19 +71,26 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-
-      - name: debug
-        run: |
-          echo "tags: ${{ steps.meta.outputs.tags }}"
-          echo "labels: ${{ steps.meta.outputs.labels }}"
+          images: ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
 
       - name: build
         run: make build-components
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build and push Docker image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        if: ${{ github.repository_owner != 'nervosnetwork'}}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # only for new tag
+      - name: Build and push Docker image to https://hub.docker.com/r/nervos/godwoken-prebuilds
+        if: ${{ github.repository_owner == 'nervosnetwork' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,108 @@
+name: Docker
+
+on:
+  # schedule:
+  #   - cron: '22 3 * * *'
+  push:
+    branches: [ main, 'docker-publish*' ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: godwoken-prebuilds
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install Rust components
+        run: rustup component add rustfmt && rustup component add clippy
+      - name: Install moleculec
+        run: |
+          test "$(moleculec --version)" = "Moleculec 0.7.2" \
+          || CARGO_TARGET_DIR=target/ cargo install moleculec --version 0.7.2 --force
+      - name: Install capsule
+        env:
+          CAPSULE_VERSION: v0.4.6
+        run: |
+          which capsule \
+          || curl -OL https://github.com/nervosnetwork/capsule/releases/download/${CAPSULE_VERSION}/capsule_${CAPSULE_VERSION}_x86_64-linux.tar.gz \
+          && tar xf capsule_${CAPSULE_VERSION}_x86_64-linux.tar.gz \
+          && mv capsule_${CAPSULE_VERSION}_x86_64-linux/capsule ~/.cargo/bin/
+          capsule --version
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      # The GHP_CRT secret is password or personal access token with `write:packages` access scope
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHP_CRT }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+
+      - name: debug
+        run: |
+          echo "tags: ${{ steps.meta.outputs.tags }}"
+          echo "labels: ${{ steps.meta.outputs.labels }}"
+
+      - name: build
+        run: make build-components
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # - name: Check versions of the binaries used by Godwoken
+      #   run: |
+      # FIXME: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by godwoken)
+      #     docker run --rm godwoken-prebuilds godwoken --version
+      #     docker run --rm godwoken-prebuilds gw-tools --version
+      ###
+      #     docker run --rm godwoken-prebuilds ckb --version
+      #     docker run --rm godwoken-prebuilds ckb-cli --version
+      #     docker run --rm godwoken-prebuilds ckb-indexer --version
+      #     docker run --rm godwoken-prebuilds find /scripts
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,26 +20,36 @@ RUN cd /ckb-indexer && unzip ckb-indexer-0.3.0-linux.zip && tar xzf ckb-indexer-
 FROM ubuntu:21.04
 MAINTAINER Xuejie Xiao <x@nervos.org>
 
-RUN apt-get update -y
-RUN apt-get install -y curl
+RUN mkdir -p /scripts/godwoken-scripts \
+ && mkdir -p /scripts/godwoken-polyjuice \
+ && mkdir -p /scripts/clerkb
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y curl \
+ && apt-get clean \
+ && echo 'Finished installing OS updates'
+
+# ckb
 COPY --from=builder /ckb/ckb_v0.100.0_x86_64-unknown-linux-gnu/ckb /bin/ckb
 COPY --from=builder /ckb/ckb_v0.100.0_x86_64-unknown-linux-gnu/ckb-cli /bin/ckb-cli
 COPY --from=builder /ckb-indexer/ckb-indexer /bin/ckb-indexer
 
+# godwoken
 COPY --from=builder /godwoken/target/release/godwoken /bin/godwoken
 COPY --from=builder /godwoken/target/release/gw-tools /bin/gw-tools
 
-RUN mkdir -p /scripts/godwoken-scripts
+# /scripts/godwoken-scripts
 COPY build/godwoken-scripts/build/release/* /scripts/godwoken-scripts/
 COPY build/godwoken-scripts/c/build/*-generator /scripts/godwoken-scripts/
 COPY build/godwoken-scripts/c/build/*-validator /scripts/godwoken-scripts/
 COPY build/godwoken-scripts/c/build/account_locks/* /scripts/godwoken-scripts/
 
-RUN mkdir -p /scripts/godwoken-polyjuice
+# /scripts/godwoken-polyjuice
 COPY build/godwoken-polyjuice/build/generator* /scripts/godwoken-polyjuice/
 COPY build/godwoken-polyjuice/build/validator* /scripts/godwoken-polyjuice/
 
-RUN mkdir -p /scripts/clerkb
+# /scripts/clerkb
 COPY build/clerkb/build/debug/poa /scripts/clerkb/
 COPY build/clerkb/build/debug/state /scripts/clerkb/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,4 @@ COPY build/godwoken-polyjuice/build/validator* /scripts/godwoken-polyjuice/
 COPY build/clerkb/build/debug/poa /scripts/clerkb/
 COPY build/clerkb/build/debug/state /scripts/clerkb/
 
-EXPOSE 3000
-
 CMD [ "godwoken", "--version" ]


### PR DESCRIPTION
## CI
- build and push image to `nervos/godwoken-prebuilds` only when a new tag is created
   please setup 2 secrets first:
      - [ ] secrets.DOCKERHUB_USERNAME
      - [ ] secrets.DOCKERHUB_TOKEN

- build and push image to `ghcr.io` if the repository_owner of fork is not nervosnetwork
   (will not push on PR)

## Successful Run
https://github.com/Flouse/godwoken-docker-prebuilds/runs/3850881253?check_suite_focus=true
