### PR TITLE
fix: tag is needed when pushing to registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -146,6 +146,7 @@ jobs:
           images: ${{ env.REGISTRY }}${{ startsWith(github.ref, 'refs/tags') && github.repository_owner == 'nervosnetwork' && 'nervos' || github.repository_owner }}/${{ env.IMAGE_NAME }}
           # dynamically set date as a suffix
           tags: |
+            type=ref,event=tag
             type=ref,event=branch,suffix=-{{date 'YYYYMMDDHHmm'}}
             type=ref,event=branch
           labels: |


### PR DESCRIPTION
fix error: tag is needed when pushing to registry
https://github.com/nervosnetwork/godwoken-docker-prebuilds/runs/5782391324?check_suite_focus=true#step:20:123