### PR TITLE
chore: install jq, tomljson in Dockerfile

### DIFF
--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -19,7 +19,7 @@ RUN mkdir -p /scripts/godwoken-scripts \
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \
- && apt-get install -y curl unzip \
+ && apt-get install -y curl unzip jq \
  && apt-get clean \
  && echo 'Finished installing OS updates'
 


### PR DESCRIPTION
We will use `jq` ~~and `tomljson`~~ in Kicker.

jq: https://stedolan.github.io/jq/
~~tomljson: https://github.com/pelletier/go-toml~~