### PR TITLE
Change Dockerfile to target the current cpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get -y install --no-install-recommends llvm-dev clang libclang-dev libss
 RUN cargo install moleculec --version 0.7.2
 
 COPY ./build/godwoken /godwoken
-# PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2: https://github.com/nervosnetwork/rust-rocksdb/blob/2de3ae5e5e23a315a477bd24e700eb4f5ef7a378/librocksdb-sys/build_detect_platform#L696-L699
-RUN cd /godwoken && rustup component add rustfmt && PORTABLE=1 USE_SSE=1 RUSTFLAGS="-C target-cpu=skylake" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
+# RocksDB uses -march=native. Let's use it too.
+RUN cd /godwoken && rustup component add rustfmt && RUSTFLAGS="-C target-cpu=native" CARGO_PROFILE_RELEASE_LTO=true cargo build --release
 
 RUN mkdir /ckb
 RUN cd /ckb && curl -LO https://github.com/nervosnetwork/ckb/releases/download/v0.100.0/ckb_v0.100.0_x86_64-unknown-linux-gnu.tar.gz

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ docker run --rm godwoken-prebuilds ckb-cli --version
 $ docker run --rm godwoken-prebuilds ckb-indexer --version
 ```
 
+## CPU Feature Requirement
+
+Starting from version 1.3.0-rc3, the published images require [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). Most recent x86-64 CPUs support AVX2. On linux, you can check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`.
+
+If your CPU/environment does not support AVX2, you can build an image that does not require AVX2 by running the build steps above on the specific CPU/environment.
+
 ## Check the reference of every component
 ```bash
 docker inspect godwoken-prebuilds:[TAG] | egrep ref.component


### PR DESCRIPTION
(Published images still target AVX2)

Document AVX2 requirement for published images and provide alternatives.